### PR TITLE
fix: prevent nil pointer dereference in IndexResult

### DIFF
--- a/main.go
+++ b/main.go
@@ -332,7 +332,7 @@ func (a *App) search(w http.ResponseWriter, r *http.Request) {
 	defer a.indexLock.RUnlock()
 
 	searchResult := a.index.Search(query, searchType, operator, dist)
-	matching_ids := a.index.Rank(searchResult.tokens, searchResult.set.ToArray())
+	matching_ids := a.index.Rank(searchResult.tokens, searchResult.DocIds())
 	result := make([]searchResponse, 0)
 
 	var response searchResponse

--- a/trie.go
+++ b/trie.go
@@ -250,6 +250,14 @@ func (r *IndexResult) CombineAnd(res *IndexResult) {
 	r.tokens = append(r.tokens, res.tokens...)
 }
 
+func (r *IndexResult) DocIds() []uint32 {
+	if r.set == nil {
+		return []uint32{}
+	}
+
+	return r.set.ToArray()
+}
+
 func (t *PatriciaTrie) mergeChildren(n *node, result *IndexResult) *IndexResult {
 	if n.isLeaf() {
 		label := t.strings[n.parent.id]


### PR DESCRIPTION
create new function to handle edge case when there is no result, therefore the bitset has not been initialized in IndexResult